### PR TITLE
fix: add extension to import

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,6 @@
 import Component, { config } from './components/SveltyPicker.svelte';
 
-export { parseDate, formatDate } from './utils/dateUtils';
+export { parseDate, formatDate } from './utils/dateUtils.js';
 
 export default Component;
 export { config };


### PR DESCRIPTION
Using the `SveltePicker` component in a component which is not of `type=module`, the following error is thrown:

```
BREAKING CHANGE: The request './utils/dateUtils' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```


This PR updates the import from `dateUtils` such that it uses the `js` extension