### PR TITLE
Implement last picker phase getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ config.i18n = {
 // default for all pickers in the app
 config.todayBtn = false;
 ```
+### Read-only properties
+| Property           | Type          | Description       |
+|--------------------|---------------|-------------------|
+| getLastPickerPhase | `function`    | Getter function to get last open picker phase (what part of date was picked last - date, hours, minutes). Takes no arguments, returns `string`, possible values: `date\|hour\|minute`. It is useful to finding out what part of date was changed on last `change` event. |
+
 ### Format settings
 
 Date format can be defined under `formatType` property. It has two options: `standard` and `php`, where


### PR DESCRIPTION
The picker has 3 distinct phases: picking date, picking hours an picking minutes.
So I implemented getter to get last phase.
Phases are: `"date"`, `"hour"` and `"minute"`.
Instance of SveltyPicker now has function `getLastPickerPhase()`, which will return last phase.

```svelte
<script>
  let picker;
  function onChange(e) {
    const phase = picker.getLastPickerPhase();
    if (phase === "minute") doSomething(e.detail)
  }
</script>
<SveltyPicker bind:this={picker} on:change={onChange} />
```