### PR TITLE
fixes date sorting in range picker mode for date formats

### DIFF
--- a/src/lib/components/SveltyPicker.svelte
+++ b/src/lib/components/SveltyPicker.svelte
@@ -201,8 +201,8 @@
   */
   function computeDisplayValue() {
     return innerDates
+      .sort((date1, date2) => date1 - date2)
       .map(innerDate => formatDate(innerDate, displayFormat || format, i18n, displayFormatType || formatType))
-      .sort()
       .join(' - ');
   }
 


### PR DESCRIPTION
Currently when using other display formats in range mode it will only get sorted by number of the day. For example **'displayFormat="j. n. Y"'** with the picked dates **2023-08-31,2023-09-01** will show as **1. 9. 2023 - 31. 8. 2023**. Sorting the dates before formatting should fix it.