### PR TITLE
fix: file extension usage for JavaScript imports

### DIFF
--- a/src/lib/components/SveltyPicker.svelte
+++ b/src/lib/components/SveltyPicker.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-  import settings from "../settings";
+  import settings from "../settings.js";
   export const config = settings;
 </script>
 
@@ -12,10 +12,10 @@
   import { fade } from "svelte/transition";
   import Calendar from "./Calendar.svelte";
   import Time from "./Time.svelte";
-  import { formatDate, parseDate } from "$lib/utils/dateUtils";
+  import { formatDate, parseDate } from "$lib/utils/dateUtils.js";
   import { usePosition } from "$lib/utils/actions.js";
-  import { computeResolvedMode, initProps } from "$lib/utils/state";
-  import { MODE_MONTH, STARTVIEW_TIME } from "$lib/utils/constants";
+  import { computeResolvedMode, initProps } from "$lib/utils/state.js";
+  import { MODE_MONTH, STARTVIEW_TIME } from "$lib/utils/constants.js";
 
   // html
   export let inputId = '';

--- a/src/lib/utils/grid.js
+++ b/src/lib/utils/grid.js
@@ -1,6 +1,6 @@
 
-import { MODE_YEAR, MODE_DECADE } from "./constants";
-import { getDaysInMonth } from "./dateUtils";
+import { MODE_YEAR, MODE_DECADE } from "./constants.js";
+import { getDaysInMonth } from "./dateUtils.js";
 
 /**
  * @typedef {object} Dataset

--- a/src/lib/utils/state.js
+++ b/src/lib/utils/state.js
@@ -1,4 +1,4 @@
-import { formatDate, parseDate } from "./dateUtils";
+import { formatDate, parseDate } from "./dateUtils.js";
 
 /**
  * @typedef {object} ValueInit


### PR DESCRIPTION
This PR fixes an issue causing module resolution to fail by specifying the file extension for JavaScript imports.

Closes #130 with the help of @jeeanribeiro :pray: 