### PR TITLE
Dispatch custom cancel event from cancel handler

### DIFF
--- a/src/lib/components/SveltyPicker.svelte
+++ b/src/lib/components/SveltyPicker.svelte
@@ -371,6 +371,7 @@
     valueArray = [...undoHistory];
     currentValue = computeStringValue();
     resetView();
+    dispatch('cancel');
   }
 
   /**


### PR DESCRIPTION
Hey @mskocik, I'm back again with another pull request, this time to add support for an optional `onCancel` callback property. The motivation behind this comes again from how I am trying to leverage this library for my use case, which amounts to creating a date picker popover component. I have no issue closing the date picker popover when a selection is made via an `on:change` callback, but the "Cancel" flow currently provided no mechanism as it doesn't trigger a change event, meaning I have no way to close the popover if a user would try to cancel out of it after opening the popover