### PR TITLE
When clicking today in range mode the whole range should be set

### DIFF
--- a/src/lib/components/SveltyPicker.svelte
+++ b/src/lib/components/SveltyPicker.svelte
@@ -348,17 +348,29 @@
     const innerDate = innerDates[0] || now;
     onDate(new CustomEvent(resolvedMode, {
       detail: {
+        dateIndex: 0,
         value: new Date(
           now.getFullYear(),
           now.getMonth(),
           now.getDate(),
-          innerDate.getHours(),
-          innerDate.getMinutes(),
+        	isRange ? 0 : innerDate.getHours(),
+          isRange ? 0 : innerDate.getMinutes(),
           0
         ),
         isKeyboard: false
       }
     }));
+    if (isRange) {
+			onDate(
+				new CustomEvent(resolvedMode, {
+					detail: {
+						dateIndex: 1,
+						value: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999),
+						isKeyboard: false
+					}
+				})
+			);
+		}
     onValueSet(true);
   }
 


### PR DESCRIPTION
https://github.com/mskocik/svelty-picker/issues/161

I modified clicking to day, to mimick setting start date and time and end date and time if in range mode

This one might need some discussion, not sure if you will agree with the proposed solution regarding time range, but it seems like what you want to select in range mode when you click on today.